### PR TITLE
Allows usage of Task Force Arrowhead Radio while unconscious

### DIFF
--- a/functions/HSC/fn_keydown.sqf
+++ b/functions/HSC/fn_keydown.sqf
@@ -67,6 +67,13 @@ _allowed pushBack (actionKeys "compass");
 if({_dikCode in _x} count _allowed > 0) then {
 	_handled = false;
 };
+
+if (_handled) then {
+    _handled = call cba_events_fnc_keyHandlerDown;
+};
+
+_handled;
+
 if(_dikCode in (actionKeys "nightVision")) then {
 	call ATHSC_fnc_toggleNV;
 };


### PR DESCRIPTION
Tested on both a dedicated server and a local host and does not introduce any dependency on CBA or any error pop ups.  Tested Enhanced Movement, Enhanced Movement Rework, and Advanced Vault System and players still cannot move their characters.  Only issue is that players can now use Magrepack to repack their magazines.  I don't know how to fix it, but seems like a minor issue overall, and also gives dead players something to do.  Other CBA based keymods might work, but I can't think of any that will cause any gameplay or balance issues.

