### PR TITLE
Revive Animation Overhaul

### DIFF
--- a/functions/Revive/fn_Drag.sqf
+++ b/functions/Revive/fn_Drag.sqf
@@ -11,8 +11,14 @@ if(call ATR_FNC_Check_Revive) then {
 
 	[_target] remoteExec ["ATR_FNC_FixRotation", 0, false];
 	
-	[player,"AcinPknlMstpSrasWrflDnon"] remoteExec ["switchMove", 0, false];
-	
+	switch (true) do
+		{
+	case (currentweapon player == ""): {[player,"AcinPknlMstpSnonWnonDnon"] remoteExec ["playmove", 0, false]};
+	case (currentweapon player == binocular player): {[player,"AcinPknlMstpSnonWnonDnon"] remoteExec ["playmove", 0, false]};
+	case (currentweapon player == (primaryweapon player)): {[player,"AcinPknlMstpSrasWrflDnon"] remoteExec ["playmove", 0, false]};
+	case (currentweapon player == (secondaryweapon player)): {[player,"AcinPknlMstpSrasWrflDnon"] remoteExec ["playmove", 0, false]};
+	case (currentweapon player == (handgunweapon player)): {[player,"AcinPknlMstpSnonWpstDnon"] remoteExec ["playmove", 0, false]};
+		};
 	//player playMoveNow "AcinPknlMstpSrasWrflDnon";
 	
 	

--- a/functions/Revive/fn_HandleRevive.sqf
+++ b/functions/Revive/fn_HandleRevive.sqf
@@ -5,31 +5,31 @@ if(!isnull _target) then {
 	if (alive _target) then
 	{
 		_target setVariable ["AT_Revive_isDragged", player, true];
-		if(primaryWeapon player != "") then {
-			//Select primary weapon so the player does not switch weapons multiple times after revive
-			private _muzzles = getArray(configFile >> "cfgWeapons" >> (primaryWeapon player) >> "muzzles");
-			if (count _muzzles > 1) then
-			{
-				 player selectWeapon (_muzzles select 0);
-			}
-			else
-			{
-				player selectWeapon (primaryWeapon player);
-			};
-			if(stance player == "PRONE") then {
-				player playMove "AinvPpneMstpSlayWnonDnon_medicOther";
-			} else {
-				player playMove "AinvPknlMstpSlayWrflDnon_medic";
-			};
-		} else {
-			player playMove "AinvPknlMstpSnonWnonDnon_medic_1";
-		};
-		sleep 6;
+		
+		switch (true) do
+		{
+		case ((currentweapon player == "") and (stance player != "PRONE")): {player playmove "AinvPknlMstpSlayWnonDnon_medicOther";};  
+		case ((currentweapon player == "") and (stance player == "PRONE")): {player playmove "AinvPpneMstpSlayWnonDnon_medicOther";}; // these first two lines have to be before the others otherwise reviving with no weapons in hand or on player results in pulling out invisible rifle and standing up after revive
+		case ((currentweapon player == (primaryweapon player)) and (stance player != "PRONE")): {player playmove "AinvPknlMstpSlayWrflDnon_medicOther";};
+		case ((currentweapon player == (secondaryweapon player)) and (stance player != "PRONE")): {player playmove "AinvPknlMstpSlayWlnrDnon_medicOther";};
+		case ((currentweapon player == (handgunweapon player)) and (stance player != "PRONE")): {player playmove "AinvPknlMstpSlayWpstDnon_medicOther";};
+		case ((currentweapon player == (primaryweapon player)) and (stance player == "PRONE")): {player playmove "AinvPpneMstpSlayWrflDnon_medicOther";};
+		case ((currentweapon player == (handgunweapon player)) and (stance player == "PRONE")): {player playmove "AinvPpneMstpSlayWpstDnon_medicOther";};
+		case ((currentweapon player == binocular player) and (stance player != "PRONE")): {player playmove "AinvPknlMstpSlayWnonDnon_medicOther";};
+		case ((currentweapon player == binocular player) and (stance player == "PRONE")): {player playmove "AinvPpneMstpSlayWnonDnon_medicOther";};
+	 	};	
+	};
+		disableUserInput true;
+		sleep 0.1;
+		disableUserInput false;
+		disableUserInput true;
+        disableUserInput false;
+		sleep 5.9;
 		_target setVariable ["AT_Revive_isDragged", objNull, true];
 		
 		if(!(player getVariable ["AT_Revive_isUnconscious",false])) then {
 			_target setVariable ["AT_Revive_isUnconscious", false, true];
-			[_target,"amovppnemstpsraswrfldnon"] remoteExec ["playmove", 0, false];
+			[_target,"AmovPpneMstpSnonWnonDnon"] remoteExec ["switchmove", 0, false]; //Changing this to "AmovPpneMstpSnonWnonDnon" fixes issue where you switch to primary then your previous weapon when you had a different weapon out initially when not pulling out of a car, but causes roll on back animation to break when pulling out of a a vehicle, so the player looks like they are just prone with no weapon equipped. Changing it from "playmove" to "switch move" fixes that issue. It does make the revive animation look a bit more janky since it snap switches instead of transitions but is worth the tradeoff in order for the player to appear dead outside of a vehicle which I believe is more important than the rolling animation.  This could be fixed if Bohemia fixes the bug with the "AinjPpneMstpSnonWnonDnon" animation and I would be able to keep the rolling on stomach animation.
 			
 			if(AT_Revive_Camera==1) then {
 				[] remoteExec ["ATHSC_fnc_exit", _target, false];
@@ -41,7 +41,7 @@ if(!isnull _target) then {
 			_target enableSimulation true;
 			_target allowDamage true;
 			_target setCaptive false;
-			[_target,"amovppnemstpsraswrfldnon"] remoteExec ["playmove", 0, false];
+			[_target,"AmovPpneMstpSnonWrflDnon"] remoteExec ["playmove", 0, false];
 		};
 		
 		//Fix revive underwater
@@ -78,7 +78,6 @@ if(!isnull _target) then {
 				_target setDamage (random 0.3)+0.1;
 			};
 		};
-	};
 } else {
 	systemchat "Target is null";
 };

--- a/functions/Revive/fn_Ragdoll.sqf
+++ b/functions/Revive/fn_Ragdoll.sqf
@@ -24,7 +24,7 @@ if(((eyepos _unit) select 2)>0.4) then {
 		};
 		
 		[_unit, false] remoteExec ["hideObject", 0, false];
-		[_unit, "AinjPpneMstpSnonWrflDnon"] remoteExec ["switchMove", 0, false];
+		[_unit, "AinjPpneMstpSnonWrflDnon"] remoteExec ["switchMove", 0, false];// this controls animation when pulling out of vehicle.  changing this to wnon version results in animation issue when pulling out of vehicle but fixes weapon swap issue.
 		
 		//If player is floating in the air, ground him
 		if((getpos _unit select 2) > 5) then {

--- a/functions/Revive/fn_Release.sqf
+++ b/functions/Revive/fn_Release.sqf
@@ -1,2 +1,11 @@
-[player,"amovpknlmstpsraswrfldnon"] remoteExec ["playMove", 0, false];
+switch (true) do
+		{
+		case (currentweapon player == ""): {[player,"AmovPknlMstpSnonWnonDnon"] remoteExec ["playmove", 0, false]}; 
+		case (currentweapon player == binocular player): {[player,"AmovPknlMstpSoptWbinDnon"] remoteExec ["playmove", 0, false]};
+		case (currentweapon player == (primaryweapon player)): {[player,"AmovPknlMstpSrasWrflDnon"] remoteExec ["playmove", 0, false]};
+		//case (currentweapon player == (primaryweapon player)): {[player,"AcinPknlMstpSrasWrflDnon_AmovPknlMstpSrasWrflDnon"] remoteExec ["playmove", 0, false]};
+		case (currentweapon player == (secondaryweapon player)): {[player,"AmovPknlMstpSrasWrflDnon"] remoteExec ["playmove", 0, false]};	
+		case (currentweapon player == (handgunweapon player)): {[player,"AmovPknlMstpSrasWpstDnon"] remoteExec ["playmove", 0, false]};	
+		};
+
 player setVariable ["AT_Revive_isDragging",objNull,true];

--- a/functions/Revive/fn_Unconscious.sqf
+++ b/functions/Revive/fn_Unconscious.sqf
@@ -38,9 +38,16 @@ if(AT_Revive_Camera==1) then {
 sleep 0.5;
 
 if(vehicle _unit == _unit) then {
-	[_unit,"AinjPpneMstpSnonWrflDnon"] remoteExec ["switchmove", 0, false];
+	[_unit,"AinjPpneMstpSnonWnonDnon"] remoteExec ["switchmove", 0, false];
 };
-_unit enableSimulation false;
+_unit enableSimulation false;  //THIS IS WHAT'S ALLOWING THE ANIMATION TO WORK IN WHEN IT SHOULDN'T "AinjPpneMstpSnonWnonDnon" NORMALLY HAS AN ISSUE WHERE THE _unit IMMEDIATELY ROLLS BACK WHEN A PRIMARY IS EQUIPPED BUT THE DISABLE SIMULATION PREVENTS THAT
+
+switch (true) do
+		{
+		case ((currentweapon _unit == (secondaryweapon _unit)) and (primaryweapon _unit != "")): {_unit selectweapon primaryweapon _unit;};
+		case (((currentweapon _unit == (secondaryweapon _unit)) and (primaryweapon _unit == "")) and (handgunweapon _unit != "")): {_unit selectweapon handgunweapon _unit;}; 
+		case (((currentweapon _unit == (secondaryweapon _unit)) and (primaryweapon _unit == "")) and (handgunweapon _unit == "")): {_unit action ["SwitchWeapon", _unit, _unit, 100];};
+		};
 
 // Call this code only on players
 if (isPlayer _unit) then 
@@ -67,7 +74,7 @@ if (isPlayer _unit) then
 	};
 	private _pos = getposATL _unit;
 	
-	// Player got revived
+	// _unit got revived
 	//sleep 6;
 	
 


### PR DESCRIPTION
The revive system has some major animation issues that lead to frustrating gameplay moments.  I've went and fixed just about every one I could within the constraints of the current script and the available animations built into Arma.  The improvements are subtle individually, but when combined greatly improve the overall feel of the mission, especially in the crucial first few minutes where a couple of the issues rear their heads frequently.  I've been testing these for the past couple months on my server with my friends and everything seems rock solid with no issues.


Major improvements

-When being revived with no weapon equipped and no weapons on back it no longer plays the stand up and put primary weapon away animation after being revived

-When being revived while carrying a launcher you no longer automatically stand up after being revived (the revive built into Arma has this issue as well). Instead you either bring out your primary, pistol, or no weapon depending on what you have available.

-Reviving while prone with a pistol out/binoculars out/no weapon out and no primary on back no longer forces you to get out of prone and crouch during the animation.

-When dragging a player while you have no weapon equipped releasing the player no longer forces you to play the stand up and put primary weapon away animation

-Fixes issue where player can skip revive animation by playing the step over command.  It's fixed by introducing a very short (0.1 second) disableuserinput command right at the start of the animation so it doesn't affect player experience.


Notable Improvements

-Fixes issue where you would unnecessarily swap weapons or play a put a way weapon animation after being revived in certain circumstances, such as being revived when you have a sidearm equipped and having a rifle on your back.  This should no longer happen under any circumstances and allows the player to move quicker after being revived.  When every millisecond counts this can keep you alive.

-Replaces some of the current revive animations to use more of the built in heal other animations.  It looks a bit nicer and easier to tell the difference between players healing others and players healing themselves.  It also has the side effect of fixing the issue where reviving without a primary equipped but a primary on your back forces you to bring out your primary when you start reviving

-Uses more of the built in drag animations to prevent unnecessary weapon swap after finishing dragging when using a pistol.


Minor Downside

-Due to some very specific quirks with certain animations and the way the revive script works the player no longer rolls over when being revived.  Instead they snap into position due to the use of a "switchmove" instead of a "playmove". I had to make a compromise in order for all of the other features to work properly.  It might be able to be fixed but it's beyond my skill set at the moment and I already spent many hours trying to fix it with no results.  I left some comments in the code for further explanations.


Known Issues

-There is still an issue where you can't move after trying to drag people and have to release the player to move.  I tried to find the exact circumstances by changing equipped weapons on both units involved, but I couldn't find a reproducible test case.  It seems to just happen randomly.  Curiously while writing this in encountered the issue while playing a test mission where I couldn't move while dragging at all.  I released and tried dragging again and again with different weapons but it just wouldn't work.  I've never seen that happen in real world gameplay. Restarting the mission fixed it. This was using a test mission without my changes.