### PR TITLE
Fix revive without eachframe

### DIFF
--- a/functions/Revive/fn_HandleDamage.sqf
+++ b/functions/Revive/fn_HandleDamage.sqf
@@ -12,8 +12,8 @@ if (_unit getVariable ["AT_Revive_isUnconscious", false]) then {
 		_amountOfDamage = 0;
 		_unit setDamage 0;
 		_unit allowDamage false;
+		[_unit, _killer, _projectile] call ATR_FNC_BroadcastKill;
 		[_unit] call ATR_FNC_Unconscious;
-		[_unit, _killer, _projectile] spawn ATR_FNC_BroadcastKill;
 	};
 };
 

--- a/functions/Revive/fn_HandleDamage.sqf
+++ b/functions/Revive/fn_HandleDamage.sqf
@@ -8,8 +8,12 @@ if (alive _unit
 	&& {_bodyPart in ["","head","face_hub","head_hit","neck","spine1","spine2","spine3","pelvis","body"]}
 ) then {
 	_amountOfDamage = 0;
-	if(count (_unit getVariable ["AT_Revive_setUnconscious", []]) == 0) then {
-		missionNamespace setvariable ["AT_Revive_setUnconscious",[_unit, _killer,_projectile]];
+	if(!(_unit getVariable ["AT_Revive_isUnconscious", false])) then {
+		_unit setDamage 0;
+		_unit allowDamage false;
+		_unit setVariable ["AT_Revive_isUnconscious", true, true];
+		[_unit] call ATR_FNC_Unconscious;
+		[_unit, _killer, _projectile] spawn ATR_FNC_BroadcastKill;
 	};
 };
 _amountOfDamage;

--- a/functions/Revive/fn_HandleDamage.sqf
+++ b/functions/Revive/fn_HandleDamage.sqf
@@ -1,4 +1,3 @@
-//params["_unit","_bodyPart","_amountOfDamage","_killer","_projectile","_context"];
 params ["_unit", "_bodyPart", "_amountOfDamage", "_killer", "_projectile", "_hitIndex", "_instigator", "_hitPoint", "_directHit", "_context"];
 
 if (_unit getVariable ["AT_Revive_isUnconscious", false]) then {

--- a/functions/Revive/fn_HandleDamage.sqf
+++ b/functions/Revive/fn_HandleDamage.sqf
@@ -1,19 +1,20 @@
 //params["_unit","_bodyPart","_amountOfDamage","_killer","_projectile","_context"];
 params ["_unit", "_bodyPart", "_amountOfDamage", "_killer", "_projectile", "_hitIndex", "_instigator", "_hitPoint", "_directHit", "_context"];
 
-
-if (alive _unit
-	&& {_amountOfDamage >= 1}
-	&& {!(_unit getVariable ["AT_Revive_isUnconscious",false])}
-	&& {_bodyPart in ["","head","face_hub","head_hit","neck","spine1","spine2","spine3","pelvis","body"]}
-) then {
+if (_unit getVariable ["AT_Revive_isUnconscious", false]) then {
 	_amountOfDamage = 0;
-	if(!(_unit getVariable ["AT_Revive_isUnconscious", false])) then {
+} else {
+	if (alive _unit
+		&& {_amountOfDamage >= 1}
+		&& {_bodyPart in ["","head","face_hub","head_hit","neck","spine1","spine2","spine3","pelvis","body"]}
+	) then {
+		_unit setVariable ["AT_Revive_isUnconscious", true, true];
+		_amountOfDamage = 0;
 		_unit setDamage 0;
 		_unit allowDamage false;
-		_unit setVariable ["AT_Revive_isUnconscious", true, true];
 		[_unit] call ATR_FNC_Unconscious;
 		[_unit, _killer, _projectile] spawn ATR_FNC_BroadcastKill;
 	};
 };
+
 _amountOfDamage;

--- a/functions/Revive/fn_HandleDamage.sqf
+++ b/functions/Revive/fn_HandleDamage.sqf
@@ -9,7 +9,7 @@ if (alive _unit
 ) then {
 	_amountOfDamage = 0;
 	if(count (_unit getVariable ["AT_Revive_setUnconscious", []]) == 0) then {
-		missionNamespace setvariable ["AT_Revive_setUnconscious",[_unit, _killer,_projectile,0]];
+		missionNamespace setvariable ["AT_Revive_setUnconscious",[_unit, _killer,_projectile]];
 	};
 };
 _amountOfDamage;

--- a/functions/Revive/fn_HandleDamage.sqf
+++ b/functions/Revive/fn_HandleDamage.sqf
@@ -8,7 +8,7 @@ if (alive _unit
 	&& {_bodyPart in ["","head","face_hub","head_hit","neck","spine1","spine2","spine3","pelvis","body"]}
 ) then {
 	_amountOfDamage = 0;
-	if(count (missionNamespace getVariable ["AT_Revive_setUnconscious", []]) == 0) then {
+	if(count (_unit getVariable ["AT_Revive_setUnconscious", []]) == 0) then {
 		missionNamespace setvariable ["AT_Revive_setUnconscious",[_unit, _killer,_projectile,0]];
 	};
 };

--- a/functions/Revive/fn_ReviveInit.sqf
+++ b/functions/Revive/fn_ReviveInit.sqf
@@ -17,20 +17,6 @@ if(isNil("AT_Revive_MinRepawnTime")) then {
 	AT_Revive_MinRepawnTime = getMissionConfigValue ["ATR_minRespawnTime", 10];
 };
 AT_Revive_Debug = false;
-if(isNil("AT_Revive_FrameEH")) then {
-	AT_Revive_FrameEH = addMissionEventHandler ["EachFrame", {
-		if(count(missionNamespace getvariable ["AT_Revive_setUnconscious",[]])>0) then {
-			AT_Revive_setUnconscious params["_unit","_killer","_projectile"];
-			missionNamespace setvariable ["AT_Revive_setUnconscious",[]];
-			_unit setDamage 0;
-			_unit allowDamage false;
-			_unit setVariable ["AT_Revive_isUnconscious", true, true];
-			[_unit] call ATR_FNC_Unconscious;
-			[_unit, _killer, _projectile] spawn ATR_FNC_BroadcastKill;
-		};
-	}];
-};
-
 [] spawn
 {
     waitUntil {!isNull player};

--- a/functions/Revive/fn_ReviveInit.sqf
+++ b/functions/Revive/fn_ReviveInit.sqf
@@ -20,17 +20,13 @@ AT_Revive_Debug = false;
 if(isNil("AT_Revive_FrameEH")) then {
 	AT_Revive_FrameEH = addMissionEventHandler ["EachFrame", {
 		if(count(missionNamespace getvariable ["AT_Revive_setUnconscious",[]])>0) then {
-			AT_Revive_setUnconscious params["_unit","_killer","_projectile","_frametimer"];
-			if(_frametimer>=3) then {
-				missionNamespace setvariable ["AT_Revive_setUnconscious",[]];
-				_unit setDamage 0;
-				_unit allowDamage false;
-				_unit setVariable ["AT_Revive_isUnconscious", true, true];
-				[_unit] spawn ATR_FNC_Unconscious;
-				[_unit, _killer, _projectile] spawn ATR_FNC_BroadcastKill;
-			} else {
-				missionNamespace setvariable ["AT_Revive_setUnconscious",[_unit,_killer,_projectile,_frametimer+1]];
-			};
+			AT_Revive_setUnconscious params["_unit","_killer","_projectile"];
+			missionNamespace setvariable ["AT_Revive_setUnconscious",[]];
+			_unit setDamage 0;
+			_unit allowDamage false;
+			_unit setVariable ["AT_Revive_isUnconscious", true, true];
+			[_unit] call ATR_FNC_Unconscious;
+			[_unit, _killer, _projectile] spawn ATR_FNC_BroadcastKill;
 		};
 	}];
 };


### PR DESCRIPTION
This PR reverts last 3 commits with `EachFrame` solution and fixes the problem with simpler approach.
To see more clearly what it changes check 93d679a commit and toggle `Ignore whitespace`.

Needs more testing but looks like it works (tested on dedicated).

Also Teamkill Report is fixed here.